### PR TITLE
Clean up achievement query style

### DIFF
--- a/VibeCoders/Repositories/SqlDataStorage.achievements.cs
+++ b/VibeCoders/Repositories/SqlDataStorage.achievements.cs
@@ -128,19 +128,12 @@ public partial class SqlDataStorage
         conn.Open();
 
         const string sql = @"
-            SELECT
-                a.achievement_id,
-                a.title,
-                a.description,
-                a.criteria,
-                CASE WHEN ca.unlocked = 1 THEN 1 ELSE 0 END AS is_unlocked
+            SELECT a.achievement_id, a.title, a.description, a.criteria,
+                   CASE WHEN COALESCE(ca.unlocked, 0) = 1 THEN 1 ELSE 0 END
             FROM ACHIEVEMENT a
             LEFT JOIN CLIENT_ACHIEVEMENT ca
-                ON ca.achievement_id = a.achievement_id
-               AND ca.client_id = @ClientId
-            ORDER BY
-                CASE WHEN COALESCE(ca.unlocked, 0) = 1 THEN 0 ELSE 1 END,
-                a.achievement_id;";
+                ON ca.achievement_id = a.achievement_id AND ca.client_id = @ClientId
+            ORDER BY COALESCE(ca.unlocked, 0) DESC, a.achievement_id;";
 
         using var cmd    = new SqliteCommand(sql, conn);
         cmd.Parameters.AddWithValue("@ClientId", clientId);
@@ -187,16 +180,11 @@ public partial class SqlDataStorage
         conn.Open();
 
         const string sql = @"
-            SELECT
-                a.achievement_id,
-                a.title,
-                a.description,
-                a.criteria,
-                CASE WHEN ca.unlocked = 1 THEN 1 ELSE 0 END AS is_unlocked
+            SELECT a.achievement_id, a.title, a.description, a.criteria,
+                   CASE WHEN COALESCE(ca.unlocked, 0) = 1 THEN 1 ELSE 0 END
             FROM ACHIEVEMENT a
             LEFT JOIN CLIENT_ACHIEVEMENT ca
-                ON ca.achievement_id = a.achievement_id
-               AND ca.client_id = @ClientId
+                ON ca.achievement_id = a.achievement_id AND ca.client_id = @ClientId
             WHERE a.achievement_id = @AchievementId;";
 
         using var cmd = new SqliteCommand(sql, conn);


### PR DESCRIPTION
The two SQL queries in SqlDataStorage.achievements.cs were using a redundant double-CASE pattern to compute unlock status and sort order. Simplified both to a single COALESCE expression so the intent is clearer and the ORDER BY reads naturally (DESC instead of mapping booleans to 0/1 manually).

No logic change, output is identical.