### PR TITLE
add GetActiveNutritionPlan on ClientService

### DIFF
--- a/VibeCoders/Services/ClientService.cs
+++ b/VibeCoders/Services/ClientService.cs
@@ -123,16 +123,25 @@ namespace VibeCoders.Services
 
         public NutritionPlan? GetActiveNutritionPlan(int clientId)
         {
-            if (clientId <= 0) return null;
+            if (clientId <= 0)
+                return null;
 
             try
             {
+                var plans = _storage.GetNutritionPlansForClient(clientId);
                 var today = DateTime.Today;
-                return _storage
-                    .GetNutritionPlansForClient(clientId)
-                    .Where(p => p.StartDate.Date <= today && today <= p.EndDate.Date)
-                    .OrderByDescending(p => p.StartDate)
-                    .FirstOrDefault();
+                NutritionPlan? best = null;
+
+                foreach (var plan in plans)
+                {
+                    if (plan.StartDate.Date > today || plan.EndDate.Date < today)
+                        continue;
+
+                    if (best == null || plan.StartDate > best.StartDate)
+                        best = plan;
+                }
+
+                return best;
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Fixes #116

Uses GetNutritionPlansForClient, filters to plans whose start/end dates include today (comparing date parts only), and if more than one matches it picks the latest StartDate.

No UI wired to this yet; it is ready for whatever screen needs the current plan.