### PR TITLE
assign nutrition plan via RelayCommand

### DIFF
--- a/VibeCoders/ViewModels/TrainerDashboardViewModel.cs
+++ b/VibeCoders/ViewModels/TrainerDashboardViewModel.cs
@@ -315,14 +315,16 @@ namespace VibeCoders.ViewModels
                 EndDate = _planEndDate.Date,
             };
 
-            _trainerService.DataStorage.SaveNutritionPlanForClient(plan, _selectedClient.Id);
+            if (!_trainerService.AssignNutritionPlan(plan, _selectedClient.Id))
+                return;
 
             AssignmentStatus =
                 $"Plan assigned to {_selectedClient.Username}: " +
                 $"{plan.StartDate:MMM d, yyyy} - {plan.EndDate:MMM d, yyyy}";
         }
 
-        public void AssignNutritionPlan(object sender, RoutedEventArgs e)
+        [RelayCommand]
+        private void AssignNutritionPlan()
         {
             AssignNutritionPlanCore();
         }

--- a/VibeCoders/Views/TrainerDashboardView.xaml
+++ b/VibeCoders/Views/TrainerDashboardView.xaml
@@ -337,7 +337,7 @@
 												Content="Assign Plan"
 												Style="{StaticResource AccentButtonStyle}"
 												IsEnabled="{x:Bind ViewModel.CanAssignPlan, Mode=OneWay}"
-												Click="{x:Bind ViewModel.AssignNutritionPlan}" />
+												Command="{x:Bind ViewModel.AssignNutritionPlanCommand}" />
 											<TextBlock
 												Grid.Column="1"
 												Text="{x:Bind ViewModel.AssignmentStatus, Mode=OneWay}"


### PR DESCRIPTION
Fixes #121

Nutrition assign button now uses AssignNutritionPlanCommand; the VM calls TrainerService.AssignNutritionPlan instead of going through DataStorage.

Stacked on #282 so you only see the view/viewmodel delta here. After #282 lands on main, either retarget this PR to main or rebase this branch and reopen against main.