### PR TITLE
Demo: in-process nutrition sync mock when external API is down

### DIFF
--- a/VibeCoders.Tests/ClientServiceNutritionSyncTests.cs
+++ b/VibeCoders.Tests/ClientServiceNutritionSyncTests.cs
@@ -1,0 +1,84 @@
+using System.Net;
+using System.Net.Http;
+using Moq;
+using VibeCoders.Models.Integration;
+using VibeCoders.Services;
+using Xunit;
+
+namespace VibeCoders.Tests;
+
+public sealed class ClientServiceNutritionSyncTests
+{
+    [Fact]
+    public async Task SyncNutritionAsync_skips_http_when_in_process_mock_enabled()
+    {
+        var storage = new Mock<IDataStorage>(MockBehavior.Loose);
+        var progression = new ProgressionService(storage.Object);
+        var httpFactory = new Mock<IHttpClientFactory>(MockBehavior.Strict);
+        var engine = new EvaluationEngine(storage.Object);
+        var bus = new Mock<IAchievementUnlockedBus>(MockBehavior.Loose);
+        var options = new NutritionSyncOptions { UseInProcessMock = true };
+
+        var svc = new ClientService(
+            storage.Object,
+            progression,
+            httpFactory.Object,
+            engine,
+            bus.Object,
+            options);
+
+        var ok = await svc.SyncNutritionAsync(new NutritionSyncPayload
+        {
+            TotalCalories = 100,
+            WorkoutDifficulty = "light",
+            UserBmi = 22.5f
+        });
+
+        Assert.True(ok);
+        httpFactory.Verify(f => f.CreateClient(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task SyncNutritionAsync_uses_http_when_mock_disabled()
+    {
+        var storage = new Mock<IDataStorage>(MockBehavior.Loose);
+        var progression = new ProgressionService(storage.Object);
+        var handler = new OkHandler();
+        var client = new HttpClient(handler);
+        var httpFactory = new Mock<IHttpClientFactory>();
+        httpFactory.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(client);
+        var engine = new EvaluationEngine(storage.Object);
+        var bus = new Mock<IAchievementUnlockedBus>(MockBehavior.Loose);
+        var options = new NutritionSyncOptions
+        {
+            UseInProcessMock = false,
+            Endpoint = "https://example.invalid/api/nutrition/sync"
+        };
+
+        var svc = new ClientService(
+            storage.Object,
+            progression,
+            httpFactory.Object,
+            engine,
+            bus.Object,
+            options);
+
+        var ok = await svc.SyncNutritionAsync(new NutritionSyncPayload
+        {
+            TotalCalories = 50,
+            WorkoutDifficulty = "moderate",
+            UserBmi = 24f
+        });
+
+        Assert.True(ok);
+        httpFactory.Verify(f => f.CreateClient(It.IsAny<string>()), Times.Once);
+    }
+
+    private sealed class OkHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken) =>
+            Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+    }
+}

--- a/VibeCoders.Tests/NutritionSyncOptionsTests.cs
+++ b/VibeCoders.Tests/NutritionSyncOptionsTests.cs
@@ -12,4 +12,11 @@ public sealed class NutritionSyncOptionsTests
         Assert.Contains("127.0.0.1", options.Endpoint, StringComparison.Ordinal);
         Assert.EndsWith("/api/nutrition/sync", options.Endpoint, StringComparison.Ordinal);
     }
+
+    [Fact]
+    public void UseInProcessMock_defaults_false_so_release_behavior_stays_real_http()
+    {
+        var options = new NutritionSyncOptions();
+        Assert.False(options.UseInProcessMock);
+    }
 }

--- a/VibeCoders.Tests/VibeCoders.Tests.csproj
+++ b/VibeCoders.Tests/VibeCoders.Tests.csproj
@@ -11,6 +11,7 @@
     <Platforms>x64</Platforms>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.2" />

--- a/VibeCoders/App.xaml.cs
+++ b/VibeCoders/App.xaml.cs
@@ -108,7 +108,12 @@ public partial class App : Application
         services.AddSingleton<ICalendarExportService, CalendarExportService>();
         services.AddSingleton<INavigationService, NavigationService>();
 
-        services.AddSingleton(new NutritionSyncOptions());
+        var nutritionSyncOptions = new NutritionSyncOptions();
+#if DEBUG
+        // Demo-friendly: other team's nutrition API often is not running during class demos.
+        nutritionSyncOptions.UseInProcessMock = true;
+#endif
+        services.AddSingleton(nutritionSyncOptions);
         services.AddSingleton<WorkoutUiState>();
 
         services.AddHttpClient();

--- a/VibeCoders/Services/ClientService.cs
+++ b/VibeCoders/Services/ClientService.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Net.Http;
 using System.Net.Http.Json;
 using VibeCoders.Models;
@@ -106,6 +107,14 @@ namespace VibeCoders.Services
             NutritionSyncPayload payload,
             CancellationToken cancellationToken = default)
         {
+            if (_nutritionSync.UseInProcessMock)
+            {
+                Debug.WriteLine(
+                    $"[NutritionSync] in-process mock: calories={payload.TotalCalories}, difficulty={payload.WorkoutDifficulty}, bmi={payload.UserBmi}");
+                await Task.Yield();
+                return true;
+            }
+
             try
             {
                 var client = _httpClientFactory.CreateClient();
@@ -117,7 +126,7 @@ namespace VibeCoders.Services
             }
             catch (Exception ex)
             {
-                System.Diagnostics.Debug.WriteLine($"Error syncing nutrition: {ex.Message}");
+                Debug.WriteLine($"Error syncing nutrition: {ex.Message}");
                 return false;
             }
         }

--- a/VibeCoders/Services/NutritionSyncOptions.cs
+++ b/VibeCoders/Services/NutritionSyncOptions.cs
@@ -6,4 +6,9 @@ namespace VibeCoders.Services;
 public sealed class NutritionSyncOptions
 {
     public string Endpoint { get; set; } = "http://127.0.0.1:5088/api/nutrition/sync";
+
+    /// <summary>
+    /// When true, sync succeeds without HTTP (for demos when the other team's API is not available).
+    /// </summary>
+    public bool UseInProcessMock { get; set; }
 }

--- a/VibeCoders/ViewModels/ClientProfileViewModel.cs
+++ b/VibeCoders/ViewModels/ClientProfileViewModel.cs
@@ -14,6 +14,7 @@ public partial class ClientProfileViewModel : ObservableObject
 {
     private readonly IDataStorage _storage;
     private readonly ClientService _clientService;
+    private readonly NutritionSyncOptions _nutritionSyncOptions;
     private int _loadedClientId;
 
     [ObservableProperty]
@@ -31,10 +32,14 @@ public partial class ClientProfileViewModel : ObservableObject
     [ObservableProperty]
     private string syncNutritionStatus = string.Empty;
 
-    public ClientProfileViewModel(IDataStorage storage, ClientService clientService)
+    public ClientProfileViewModel(
+        IDataStorage storage,
+        ClientService clientService,
+        NutritionSyncOptions nutritionSyncOptions)
     {
         _storage = storage;
         _clientService = clientService;
+        _nutritionSyncOptions = nutritionSyncOptions;
     }
 
     [RelayCommand]
@@ -70,9 +75,20 @@ public partial class ClientProfileViewModel : ObservableObject
         };
 
         var ok = await _clientService.SyncNutritionAsync(payload).ConfigureAwait(true);
-        SyncNutritionStatus = ok
-            ? "Nutrition sync OK."
-            : "Sync failed — start your local nutrition API (see NutritionSyncOptions default URL) or check the network.";
+        if (ok && _nutritionSyncOptions.UseInProcessMock)
+        {
+            SyncNutritionStatus =
+                "Nutrition sync OK (demo mock — no HTTP, flip UseInProcessMock off when their API is up).";
+        }
+        else if (ok)
+        {
+            SyncNutritionStatus = "Nutrition sync OK.";
+        }
+        else
+        {
+            SyncNutritionStatus =
+                "Sync failed — start your local nutrition API (see NutritionSyncOptions default URL) or check the network.";
+        }
     }
 
     public void LoadClientData(int clientId)


### PR DESCRIPTION
This is for demos when the other team's nutrition API is not running. Real HTTP stays the default in Release; Debug turns on an in-process mock so sync can succeed without localhost. The client profile shows a short note when the mock path was used so it is obvious in recordings.

Turn the mock off when their API is up, the endpoint string still applies whenever mock is false.